### PR TITLE
Add workflow to keep PSite branch updated

### DIFF
--- a/.github/workflows/sync-psite.yml
+++ b/.github/workflows/sync-psite.yml
@@ -1,0 +1,25 @@
+name: Sync PSite branch
+
+on:
+  push:
+    branches:
+      - work
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push HEAD to PSite branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git push origin HEAD:PSite

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # TruMetraPla
+
 TruMetraPla monitora la produttività nei processi metalmeccanici, importando dati da file Excel e mostrando una dashboard con KPI, grafici e analisi su quantità, tipologia di processo e rendimento dei dipendenti.
+
+## Branch di sincronizzazione
+
+Per evitare l'errore `fatal: couldn't find remote ref PSite` durante le operazioni automatiche di fetch, il repository include ora un workflow GitHub Actions che mantiene aggiornato il branch `PSite` sincronizzandolo con l'ultimo commit dei branch principali (`work`, `main` o `master`). In questo modo gli script esterni che fanno riferimento a `PSite` troveranno sempre la relativa ref remota.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that pushes the latest commit from the primary branches to PSite so the remote ref always exists
- document the automated PSite sync in the README to explain the resolution of the missing ref error

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3e32f499c832d9b206a634ab3a3cd