### PR TITLE
Improve quantity column auto-detection

### DIFF
--- a/src/trumetrapla/data_loader.py
+++ b/src/trumetrapla/data_loader.py
@@ -15,7 +15,13 @@ _DEFAULT_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "date": ("data", "date", "giorno"),
     "employee": ("dipendente", "operatore", "employee"),
     "process": ("processo", "fase", "process"),
-    "quantity": ("quantità", "pezzi", "quantity", "pieces"),
+    "quantity": (
+        "quantità",
+        "pezzi",
+        "pezzi prodotti",
+        "quantity",
+        "pieces",
+    ),
     "duration_minutes": ("durata (min)", "durata", "minuti", "duration", "minutes"),
 }
 
@@ -136,10 +142,11 @@ def _resolve_column_name(
             return normalized_columns[token]
 
     raise ColumnMappingError(
-        """
-        Impossibile individuare la colonna per il campo '{field}'. Specificare
-        'column_mapping' o rinominare le intestazioni nel file Excel.
-        """.strip()
+        (
+            "Impossibile individuare la colonna per il campo "
+            f"'{field}'. Specificare 'column_mapping' o rinominare le "
+            "intestazioni nel file Excel."
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- add "Pezzi prodotti" to the default aliases for the quantity column so Excel files with that header are detected automatically
- clarify the missing-column error message by including the field name

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e434b7e4fc832d9cc715445f683da9