### PR TITLE
Handle welcome_app execution outside package context

### DIFF
--- a/src/trumetrapla/welcome_app.py
+++ b/src/trumetrapla/welcome_app.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+import pathlib
 import sys
 from typing import Iterable, Sequence
 
-from .gui import GUIUnavailableError, launch_welcome_window
+
+def _is_running_as_script() -> bool:
+    return __package__ in (None, "")
+
+
+if _is_running_as_script():
+    package_root = pathlib.Path(__file__).resolve().parent.parent
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    from trumetrapla.gui import GUIUnavailableError, launch_welcome_window  # type: ignore
+else:
+    from .gui import GUIUnavailableError, launch_welcome_window
 
 
 def run(argv: Sequence[str] | None = None) -> None:
@@ -25,7 +37,10 @@ def run(argv: Sequence[str] | None = None) -> None:
 
 
 def _run_cli(arguments: Iterable[str]) -> None:
-    from .cli import main as cli_main
+    if _is_running_as_script():
+        from trumetrapla.cli import main as cli_main  # type: ignore
+    else:
+        from .cli import main as cli_main
 
     cli_main.main(args=list(arguments), prog_name="TruMetraPla", standalone_mode=False)
 


### PR DESCRIPTION
## Summary
- ensure the welcome app adjusts sys.path when launched as a standalone script so relative imports succeed
- mirror the same logic for CLI imports to keep the fallback path working

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e436ed2424832d99c4fa62445dd41c