### PR TITLE
Handle welcome_app execution outside package context and add Windows build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ trumetrapla report produzione.xlsx --column quantity "Pezzi prodotti" --alias em
 ## Costruire l'eseguibile Windows
 
 1. Installa le dipendenze di build: `pip install .[build]` (su Windows con Python 3.11 o superiore) oppure esegui lo script `powershell -ExecutionPolicy Bypass -File installer/Setup-TruMetraPla.ps1`.
-2. Genera l'eseguibile lanciando `trumetrapla build-exe`, utilizzando il menu interattivo oppure affidandoti allo script PowerShell. Verrà creato `TruMetraPla.exe` nella cartella `dist/`; facendo doppio clic sull'eseguibile si aprirà direttamente la finestra grafica di benvenuto.
+2. Genera l'eseguibile lanciando `trumetrapla build-exe`, utilizzando il menu interattivo, lo script PowerShell **oppure il nuovo file batch** `installer/Build-TruMetraPla.bat`. Verrà creato `TruMetraPla.exe` nella cartella `dist/`; facendo doppio clic sull'eseguibile si aprirà direttamente la finestra grafica di benvenuto.
 3. (Opzionale ma consigliato) Compila l'installer grafico con `trumetrapla build-installer`. Il comando crea `TruMetraPla_Setup_<versione>.exe` pronto per l'utente finale.
 
 ### Creare l'installer automatico
@@ -110,17 +110,21 @@ Se desideri rigenerare da zero anche l'eseguibile (ignorando eventuali build pre
 
 ### Automazione da PowerShell
 
-Per Windows è disponibile lo script `installer/Setup-TruMetraPla.ps1` che:
+Per Windows sono disponibili gli script `installer/Setup-TruMetraPla.ps1` (PowerShell) e `installer/Build-TruMetraPla.bat` (Prompt dei comandi) che:
 
 - crea o aggiorna un ambiente virtuale dedicato;
 - installa il progetto con le dipendenze necessarie alla build;
-- invoca `trumetrapla build-exe` con la cartella di destinazione desiderata;
+- invocano `trumetrapla build-exe` con la cartella di destinazione desiderata;
 - opzionalmente compila l'installer grafico NSIS (parametro `-IncludeInstaller`, che usa `trumetrapla build-installer`).
 
 Esempio di utilizzo completo:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File installer/Setup-TruMetraPla.ps1 -IncludeInstaller
+```
+
+```bat
+installer\Build-TruMetraPla.bat --dist C:\Percorso\Output
 ```
 
 ## Utilizzo come libreria Python

--- a/installer/Build-TruMetraPla.bat
+++ b/installer/Build-TruMetraPla.bat
@@ -1,0 +1,100 @@
+@echo off
+setlocal
+
+if "%~1"=="/?" goto :show_help
+if "%~1"=="--help" goto :show_help
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR%"=="" set "SCRIPT_DIR=%CD%\\"
+pushd "%SCRIPT_DIR%.."
+set "REPO_ROOT=%CD%"
+
+set "DIST_DIR="
+set "ONEFILE_FLAG=--onefile"
+
+:parse_args
+if "%~1"=="" goto :args_done
+if /I "%~1"=="--dist" (
+    shift
+    if "%~1"=="" (
+        echo Errore: manca il percorso dopo --dist.
+        goto :error_exit
+    )
+    set "DIST_DIR=%~f1"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--portable" (
+    set "ONEFILE_FLAG=--no-onefile"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--onefile" (
+    set "ONEFILE_FLAG=--onefile"
+    shift
+    goto :parse_args
+)
+echo Opzione sconosciuta: %~1
+goto :error_exit
+
+:args_done
+if "%DIST_DIR%"=="" set "DIST_DIR=%REPO_ROOT%\\dist"
+if not exist "%DIST_DIR%" mkdir "%DIST_DIR%" >nul
+
+for %%I in (python.exe) do set "PYTHON_PATH=%%~$PATH:I"
+if "%PYTHON_PATH%"=="" (
+    echo Errore: Python 3.11+ non trovato nel PATH.
+    echo Installa Python e riprova.
+    goto :error_exit
+)
+
+set "VENV_DIR=%REPO_ROOT%\\.venv-trumetrapla-build"
+set "VENV_PYTHON=%VENV_DIR%\\Scripts\\python.exe"
+set "VENV_PIP=%VENV_DIR%\\Scripts\\pip.exe"
+
+if not exist "%VENV_DIR%" (
+    echo Creazione ambiente virtuale...
+    "%PYTHON_PATH%" -m venv "%VENV_DIR%"
+)
+
+if not exist "%VENV_PYTHON%" (
+    echo Errore: ambiente virtuale non valido (python.exe mancante).
+    goto :error_exit
+)
+
+echo Aggiornamento pip...
+"%VENV_PYTHON%" -m pip install --upgrade pip --quiet
+if errorlevel 1 goto :error_exit
+
+echo Installazione del progetto con dipendenze di build...
+"%VENV_PIP%" install "%REPO_ROOT%[build]" --quiet
+if errorlevel 1 goto :error_exit
+
+echo Generazione eseguibile TruMetraPla.exe...
+"%VENV_PYTHON%" -m trumetrapla.cli build-exe --dist "%DIST_DIR%" %ONEFILE_FLAG%
+if errorlevel 1 goto :error_exit
+
+if exist "%DIST_DIR%\\TruMetraPla.exe" (
+    echo ^> Eseguibile creato in: "%DIST_DIR%\\TruMetraPla.exe"
+) else (
+    echo Avviso: TruMetraPla.exe non trovato in "%DIST_DIR%".
+)
+
+echo Operazione completata.
+popd
+endlocal
+exit /b 0
+
+:show_help
+echo TruMetraPla build automatico
+echo Uso: Build-TruMetraPla.bat [--dist cartella] [--portable^|--onefile]
+echo    --dist      Imposta la cartella di output (default: dist\\)
+echo    --portable  Genera la build in modalita^ portabile (cartella con dipendenze)
+echo    --onefile   Forza la modalita^ onefile (default)
+echo    --help, /?  Mostra questo messaggio
+exit /b 0
+
+:error_exit
+popd
+endlocal
+exit /b 1

--- a/src/trumetrapla/welcome_app.py
+++ b/src/trumetrapla/welcome_app.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+import pathlib
 import sys
 from typing import Iterable, Sequence
 
-from .gui import GUIUnavailableError, launch_welcome_window
+
+def _is_running_as_script() -> bool:
+    return __package__ in (None, "")
+
+
+if _is_running_as_script():
+    package_root = pathlib.Path(__file__).resolve().parent.parent
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    from trumetrapla.gui import GUIUnavailableError, launch_welcome_window  # type: ignore
+else:
+    from .gui import GUIUnavailableError, launch_welcome_window
 
 
 def run(argv: Sequence[str] | None = None) -> None:
@@ -25,7 +37,10 @@ def run(argv: Sequence[str] | None = None) -> None:
 
 
 def _run_cli(arguments: Iterable[str]) -> None:
-    from .cli import main as cli_main
+    if _is_running_as_script():
+        from trumetrapla.cli import main as cli_main  # type: ignore
+    else:
+        from .cli import main as cli_main
 
     cli_main.main(args=list(arguments), prog_name="TruMetraPla", standalone_mode=False)
 


### PR DESCRIPTION
## Summary
- ensure the welcome app adjusts sys.path when launched as a standalone script so relative imports succeed
- mirror the same logic for CLI imports to keep the fallback path working
- add a Windows batch helper that automates `trumetrapla build-exe` and document its usage in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e436ed2424832d99c4fa62445dd41c