### PR TITLE
Add pie chart viewer to desktop dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TruMetraPla monitora la produttività nei processi metalmeccanici importando dat
 - Import automatico di file Excel con riconoscimento delle intestazioni italiane e inglesi.
 - Calcolo dei principali indicatori: pezzi prodotti, ore lavorate, produttività media.
 - Aggregazioni per dipendente, processo e giorno con ordinamento per produttività.
-- Consolle grafica moderna con menu a tendina, filtri e tabella interattiva per analizzare i file Excel.
+- Consolle grafica moderna con menu a tendina, filtri, tabella interattiva e grafico a torta per analizzare i file Excel.
 - Eseguibile Windows che apre una dashboard desktop con caricamento file guidato e riepiloghi KPI.
 
 ## Installazione
@@ -54,7 +54,7 @@ La schermata principale offre:
 - **Menu File** con la voce *Apri file Excel…* per selezionare il file da importare.
 - **Filtri a tendina** per isolare rapidamente un singolo dipendente o processo produttivo.
 - **Tabella interattiva** con le colonne normalizzate (data, dipendente, processo, pezzi, durata e produttività oraria).
-- **Pulsante "Mostra KPI"** per visualizzare un riepilogo dei principali indicatori e delle top performance.
+- **Pulsanti "Mostra KPI" e "Grafico a torta"** per aprire rispettivamente il riepilogo numerico e la distribuzione visiva dei pezzi prodotti.
 
 Al caricamento viene aggiornato lo stato nella barra inferiore, insieme al riepilogo dei totali (pezzi, ore, throughput e numero di dipendenti/processi). In assenza del runtime grafico Windows, l'applicazione ripiega automaticamente sulla CLI.
 
@@ -81,7 +81,7 @@ trumetrapla report produzione.xlsx --column quantity "Pezzi prodotti" --alias em
 ## Costruire l'eseguibile Windows
 
 1. Installa le dipendenze di build: `pip install .[build]` (su Windows con Python 3.11 o superiore) oppure esegui lo script `powershell -ExecutionPolicy Bypass -File installer/Setup-TruMetraPla.ps1`.
-2. Genera l'eseguibile lanciando `trumetrapla build-exe`, utilizzando il menu interattivo oppure affidandoti allo script PowerShell. Verrà creato `TruMetraPla.exe` nella cartella `dist/`; facendo doppio clic sull'eseguibile si aprirà direttamente la finestra grafica di benvenuto.
+2. Genera l'eseguibile lanciando `trumetrapla build-exe`, utilizzando il menu interattivo, lo script PowerShell **oppure il nuovo file batch** `installer/Build-TruMetraPla.bat`. Verrà creato `TruMetraPla.exe` nella cartella `dist/`; facendo doppio clic sull'eseguibile si aprirà direttamente la finestra grafica di benvenuto.
 3. (Opzionale ma consigliato) Compila l'installer grafico con `trumetrapla build-installer`. Il comando crea `TruMetraPla_Setup_<versione>.exe` pronto per l'utente finale.
 
 ### Creare l'installer automatico
@@ -110,17 +110,21 @@ Se desideri rigenerare da zero anche l'eseguibile (ignorando eventuali build pre
 
 ### Automazione da PowerShell
 
-Per Windows è disponibile lo script `installer/Setup-TruMetraPla.ps1` che:
+Per Windows sono disponibili gli script `installer/Setup-TruMetraPla.ps1` (PowerShell) e `installer/Build-TruMetraPla.bat` (Prompt dei comandi) che:
 
 - crea o aggiorna un ambiente virtuale dedicato;
 - installa il progetto con le dipendenze necessarie alla build;
-- invoca `trumetrapla build-exe` con la cartella di destinazione desiderata;
+- invocano `trumetrapla build-exe` con la cartella di destinazione desiderata;
 - opzionalmente compila l'installer grafico NSIS (parametro `-IncludeInstaller`, che usa `trumetrapla build-installer`).
 
 Esempio di utilizzo completo:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File installer/Setup-TruMetraPla.ps1 -IncludeInstaller
+```
+
+```bat
+installer\Build-TruMetraPla.bat --dist C:\Percorso\Output
 ```
 
 ## Utilizzo come libreria Python

--- a/installer/Build-TruMetraPla.bat
+++ b/installer/Build-TruMetraPla.bat
@@ -1,0 +1,100 @@
+@echo off
+setlocal
+
+if "%~1"=="/?" goto :show_help
+if "%~1"=="--help" goto :show_help
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR%"=="" set "SCRIPT_DIR=%CD%\\"
+pushd "%SCRIPT_DIR%.."
+set "REPO_ROOT=%CD%"
+
+set "DIST_DIR="
+set "ONEFILE_FLAG=--onefile"
+
+:parse_args
+if "%~1"=="" goto :args_done
+if /I "%~1"=="--dist" (
+    shift
+    if "%~1"=="" (
+        echo Errore: manca il percorso dopo --dist.
+        goto :error_exit
+    )
+    set "DIST_DIR=%~f1"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--portable" (
+    set "ONEFILE_FLAG=--no-onefile"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--onefile" (
+    set "ONEFILE_FLAG=--onefile"
+    shift
+    goto :parse_args
+)
+echo Opzione sconosciuta: %~1
+goto :error_exit
+
+:args_done
+if "%DIST_DIR%"=="" set "DIST_DIR=%REPO_ROOT%\\dist"
+if not exist "%DIST_DIR%" mkdir "%DIST_DIR%" >nul
+
+for %%I in (python.exe) do set "PYTHON_PATH=%%~$PATH:I"
+if "%PYTHON_PATH%"=="" (
+    echo Errore: Python 3.11+ non trovato nel PATH.
+    echo Installa Python e riprova.
+    goto :error_exit
+)
+
+set "VENV_DIR=%REPO_ROOT%\\.venv-trumetrapla-build"
+set "VENV_PYTHON=%VENV_DIR%\\Scripts\\python.exe"
+set "VENV_PIP=%VENV_DIR%\\Scripts\\pip.exe"
+
+if not exist "%VENV_DIR%" (
+    echo Creazione ambiente virtuale...
+    "%PYTHON_PATH%" -m venv "%VENV_DIR%"
+)
+
+if not exist "%VENV_PYTHON%" (
+    echo Errore: ambiente virtuale non valido (python.exe mancante).
+    goto :error_exit
+)
+
+echo Aggiornamento pip...
+"%VENV_PYTHON%" -m pip install --upgrade pip --quiet
+if errorlevel 1 goto :error_exit
+
+echo Installazione del progetto con dipendenze di build...
+"%VENV_PIP%" install "%REPO_ROOT%[build]" --quiet
+if errorlevel 1 goto :error_exit
+
+echo Generazione eseguibile TruMetraPla.exe...
+"%VENV_PYTHON%" -m trumetrapla.cli build-exe --dist "%DIST_DIR%" %ONEFILE_FLAG%
+if errorlevel 1 goto :error_exit
+
+if exist "%DIST_DIR%\\TruMetraPla.exe" (
+    echo ^> Eseguibile creato in: "%DIST_DIR%\\TruMetraPla.exe"
+) else (
+    echo Avviso: TruMetraPla.exe non trovato in "%DIST_DIR%".
+)
+
+echo Operazione completata.
+popd
+endlocal
+exit /b 0
+
+:show_help
+echo TruMetraPla build automatico
+echo Uso: Build-TruMetraPla.bat [--dist cartella] [--portable^|--onefile]
+echo    --dist      Imposta la cartella di output (default: dist\\)
+echo    --portable  Genera la build in modalita^ portabile (cartella con dipendenze)
+echo    --onefile   Forza la modalita^ onefile (default)
+echo    --help, /?  Mostra questo messaggio
+exit /b 0
+
+:error_exit
+popd
+endlocal
+exit /b 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ authors = [
 dependencies = [
     "pandas>=2.2",
     "openpyxl>=3.1",
-    "click>=8.1"
+    "click>=8.1",
+    "matplotlib>=3.8"
 ]
 license = {file = "LICENSE"}
 

--- a/src/trumetrapla/gui.py
+++ b/src/trumetrapla/gui.py
@@ -271,11 +271,124 @@ def launch_welcome_window(
 
         messagebox.showinfo("KPI principali", message)
 
+    def _show_pie_chart() -> None:
+        records = state.filtered_records or state.records
+        if not records:
+            messagebox.showinfo(
+                "Nessun dato",
+                "Carica un file Excel e applica eventuali filtri per generare il grafico.",
+            )
+            return
+
+        try:
+            from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+            from matplotlib.figure import Figure
+        except ModuleNotFoundError:  # pragma: no cover - dipendenza opzionale
+            messagebox.showerror(
+                "Matplotlib non disponibile",
+                "Installa la dipendenza opzionale 'matplotlib' per visualizzare i grafici.",
+            )
+            return
+        except Exception as exc:  # pragma: no cover - errori imprevisti
+            messagebox.showerror(
+                "Errore grafico",
+                f"Impossibile inizializzare il motore di grafici: {exc}",
+            )
+            return
+
+        chart_window = tk.Toplevel(root)
+        chart_window.title("Report grafico TruMetraPla")
+        chart_window.geometry("720x520")
+        try:
+            chart_window.minsize(560, 420)
+        except Exception:  # pragma: no cover - alcuni stub non implementano minsize
+            pass
+
+        container = ttk.Frame(chart_window, padding=16)
+        container.pack(fill="both", expand=True)
+
+        heading = ttk.Label(
+            container,
+            text="Distribuzione dei pezzi prodotti",
+            font=("Segoe UI", 12, "bold"),
+        )
+        heading.pack(anchor="w")
+
+        options_frame = ttk.Frame(container)
+        options_frame.pack(fill="x", pady=(12, 8))
+
+        ttk.Label(options_frame, text="Raggruppa per:").pack(side="left")
+
+        grouping_combo = ttk.Combobox(
+            options_frame,
+            state="readonly",
+            values=["Processo", "Dipendente"],
+            width=20,
+        )
+        grouping_combo.current(0)
+        grouping_combo.pack(side="left", padx=8)
+
+        figure = Figure(figsize=(5.8, 4.2), dpi=100)
+        axis = figure.add_subplot(111)
+        canvas = FigureCanvasTkAgg(figure, master=container)
+        canvas.get_tk_widget().pack(fill="both", expand=True)
+
+        info_var = tk.StringVar(value="")
+        ttk.Label(container, textvariable=info_var, wraplength=660, justify="center").pack(
+            fill="x", pady=(8, 0)
+        )
+
+        def _refresh_chart(*_args: object) -> None:
+            selected = grouping_combo.get()
+            if selected == "Dipendente":
+                breakdown = group_by_employee(records)
+                title = "Distribuzione pezzi per dipendente"
+            else:
+                breakdown = group_by_process(records)
+                title = "Distribuzione pezzi per processo"
+
+            filtered_breakdown = [
+                item for item in breakdown if item.total_quantity > 0
+            ]
+
+            if not filtered_breakdown:
+                info_var.set(
+                    "Non sono disponibili dati con quantità positive per il grafico selezionato."
+                )
+                axis.clear()
+                canvas.draw_idle()
+                return
+
+            info_var.set("")
+            axis.clear()
+
+            values = [item.total_quantity for item in filtered_breakdown]
+            labels = [item.entity for item in filtered_breakdown]
+            total = sum(values)
+
+            def _format_pct(pct: float) -> str:
+                absolute = int(round(pct * total / 100.0))
+                return f"{pct:.1f}% ({absolute} pezzi)"
+
+            axis.pie(
+                values,
+                labels=labels,
+                autopct=_format_pct,
+                startangle=90,
+            )
+            axis.set_title(title)
+            axis.axis("equal")
+            canvas.draw_idle()
+
+        grouping_combo.bind("<<ComboboxSelected>>", _refresh_chart)
+        _refresh_chart()
+
     file_menu.add_command(label="Apri file Excel…", command=_open_file)
     file_menu.add_separator()
     file_menu.add_command(label="Esci", command=root.destroy)
 
     tools_menu.add_command(label="Mostra KPI filtrati", command=_show_kpi_dialog)
+    tools_menu.add_command(label="Grafico a torta", command=_show_pie_chart)
 
     def _open_docs() -> None:
         import webbrowser
@@ -373,6 +486,9 @@ def launch_welcome_window(
 
     ttk.Button(footer, text="Apri file Excel…", command=_open_file).pack(side="left")
     ttk.Button(footer, text="Mostra KPI", command=_show_kpi_dialog).pack(side="left", padx=8)
+    ttk.Button(footer, text="Grafico a torta", command=_show_pie_chart).pack(
+        side="left", padx=8
+    )
     ttk.Label(footer, textvariable=status_var).pack(side="right")
 
     employee_combo.bind("<<ComboboxSelected>>", lambda *_: _apply_filters())
@@ -381,6 +497,7 @@ def launch_welcome_window(
     commands: dict[str, Callable[[], None]] = {
         "open_file": _open_file,
         "show_kpi": _show_kpi_dialog,
+        "show_chart": _show_pie_chart,
         "apply_filters": _apply_filters,
     }
 

--- a/src/trumetrapla/welcome_app.py
+++ b/src/trumetrapla/welcome_app.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+import pathlib
 import sys
 from typing import Iterable, Sequence
 
-from .gui import GUIUnavailableError, launch_welcome_window
+
+def _is_running_as_script() -> bool:
+    return __package__ in (None, "")
+
+
+if _is_running_as_script():
+    package_root = pathlib.Path(__file__).resolve().parent.parent
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    from trumetrapla.gui import GUIUnavailableError, launch_welcome_window  # type: ignore
+else:
+    from .gui import GUIUnavailableError, launch_welcome_window
 
 
 def run(argv: Sequence[str] | None = None) -> None:
@@ -25,7 +37,10 @@ def run(argv: Sequence[str] | None = None) -> None:
 
 
 def _run_cli(arguments: Iterable[str]) -> None:
-    from .cli import main as cli_main
+    if _is_running_as_script():
+        from trumetrapla.cli import main as cli_main  # type: ignore
+    else:
+        from .cli import main as cli_main
 
     cli_main.main(args=list(arguments), prog_name="TruMetraPla", standalone_mode=False)
 


### PR DESCRIPTION
## Summary
- extend the desktop dashboard with a pie-chart window that visualizes filtered production data by process or employee
- expose the new chart through both the tools menu and footer button while documenting it in the README
- add matplotlib as a dependency so the application can render the embedded chart canvas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e436ed2424832d99c4fa62445dd41c