### PR TITLE
Fix Treeview column configuration in GUI

### DIFF
--- a/src/trumetrapla/data_loader.py
+++ b/src/trumetrapla/data_loader.py
@@ -149,17 +149,8 @@ def load_operations_from_excel(
     normalized = normalized.dropna(subset=["date", "employee", "process"])
 
     canonical_columns = list(_CANONICAL_FIELDS)
-    records = [
-        OperationRecord(
-            date=row["date"],
-            employee=_coerce_text(row["employee"]),
-            process=_coerce_text(row["process"]),
-            machine=_coerce_text(row.get("machine", "")),
-            process_type=_coerce_text(row.get("process_type", "")),
-            quantity=int(row["quantity"]),
-            duration_minutes=float(row["duration_minutes"]),
-        )
-        for row in normalized[canonical_columns].to_dict(orient="records")
+    extras_columns = [
+        column for column in normalized.columns if column not in canonical_columns
     ]
 
     records: list[OperationRecord] = []

--- a/src/trumetrapla/gui.py
+++ b/src/trumetrapla/gui.py
@@ -335,20 +335,21 @@ def launch_welcome_window(
         tree.delete(*tree.get_children())
         columns = _active_columns()
         for record in records:
-            tree.insert(
-                "",
-                "end",
-                values=(
-                    record.date.strftime("%d/%m/%Y"),
-                    record.employee,
-                    record.process,
-                    record.process_type or "-",
-                    record.machine or "-",
-                    f"{record.quantity}",
-                    f"{record.duration_minutes:.1f}",
-                    f"{record.productivity_per_hour:.2f}",
-                ),
-            )
+            values: list[str] = []
+            for column_id in columns:
+                spec = state.column_specs.get(column_id)
+                if spec is None:
+                    values.append("")
+                    continue
+                try:
+                    value = spec.getter(record)
+                except Exception:  # pragma: no cover - getter personalizzato errato
+                    value = ""
+                if not isinstance(value, str):
+                    value = "" if value is None else str(value)
+                values.append(value)
+
+            tree.insert("", "end", values=tuple(values))
 
     def _format_summary(records: list[OperationRecord]) -> str:
         if not records:
@@ -939,16 +940,6 @@ def launch_welcome_window(
     table_frame = ttk.Frame(main_frame, padding=12, style="Card.TFrame")
     table_frame.pack(fill="both", expand=True)
 
-    columns = (
-        "date",
-        "employee",
-        "process",
-        "process_type",
-        "machine",
-        "quantity",
-        "duration",
-        "throughput",
-    )
     tree = ttk.Treeview(
         table_frame,
         columns=tuple(state.visible_columns),
@@ -957,27 +948,6 @@ def launch_welcome_window(
         style="Tech.Treeview",
     )
 
-    headings = {
-        "date": "Data",
-        "employee": "Dipendente",
-        "process": "Processo",
-        "process_type": "Tipo processo",
-        "machine": "Macchina",
-        "quantity": "Pezzi",
-        "duration": "Durata (min)",
-        "throughput": "Pezzi/ora",
-    }
-
-    for column in columns:
-        tree.heading(column, text=headings[column])
-        anchor = "center"
-        if column in {"employee", "process", "process_type", "machine"}:
-            anchor = "w"
-        width = 140
-        if column in {"quantity", "duration", "throughput"}:
-            width = 110
-        tree.column(column, anchor=anchor, width=width)
-
     vsb = ttk.Scrollbar(table_frame, orient="vertical", command=tree.yview)
     hsb = ttk.Scrollbar(table_frame, orient="horizontal", command=tree.xview)
     tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
@@ -985,6 +955,8 @@ def launch_welcome_window(
     tree.pack(side="left", fill="both", expand=True)
     vsb.pack(side="left", fill="y")
     hsb.pack(side="bottom", fill="x")
+
+    _configure_tree_columns()
 
     footer = ttk.Frame(main_frame, style="Dashboard.TFrame")
     footer.pack(fill="x", pady=(12, 0))


### PR DESCRIPTION
## Summary
- remove the hard-coded Treeview headers so the GUI uses the dynamic column specifications
- build table rows from the configured column specs to support optional columns safely
- restore Excel loader extras column detection to avoid NameError when opening files

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'trumetrapla')*

------
https://chatgpt.com/codex/tasks/task_e_68e5370beeec832d99b151f03dcc1028